### PR TITLE
Remove dead store

### DIFF
--- a/itostr.c
+++ b/itostr.c
@@ -31,7 +31,7 @@ size_t signedtostr(intmax_t value, size_t valsize, char *buffer, size_t bufsize,
     *buffer = '0';
     return (size_t)0;
   }
-  uintmax_t signmask = UINTMAX_C(128) << ((--valsize) << 3), typemask = (signmask << 1) - 1; // signmask: one bit set at the MSB position of the passed type, typemask: all bits set in the range of the passed type
+  uintmax_t signmask = UINTMAX_C(128) << ((valsize-1) << 3), typemask = (signmask << 1) - 1; // signmask: one bit set at the MSB position of the passed type, typemask: all bits set in the range of the passed type
   return base == 10 && ((uintmax_t)value & signmask) != UINTMAX_C(0) // decide if the value shall be unsigned or negative, mask out all bits which exceed the passed type size using one-bits (negative value) or zero-bits (unsigned value)
          ? signeddecstrconv_impl((intmax_t)((uintmax_t)value | ~typemask), buffer, bufsize)
          : unsignedstrconv_impl((uintmax_t)value & typemask, buffer, bufsize, base);
@@ -46,7 +46,7 @@ size_t signedtowcs(intmax_t value, size_t valsize, wchar_t *buffer, size_t bufsi
     *buffer = L'0';
     return (size_t)0;
   }
-  uintmax_t signmask = UINTMAX_C(128) << ((--valsize) << 3), typemask = (signmask << 1) - 1;
+  uintmax_t signmask = UINTMAX_C(128) << ((valsize-1) << 3), typemask = (signmask << 1) - 1;
   return base == 10 && ((uintmax_t)value & signmask) != UINTMAX_C(0)
          ? signeddecwcsconv_impl((intmax_t)((uintmax_t)value | ~typemask), buffer, bufsize)
          : unsignedwcsconv_impl((uintmax_t)value & typemask, buffer, bufsize, base);
@@ -61,7 +61,7 @@ size_t unsignedtostr(uintmax_t value, size_t valsize, char *buffer, size_t bufsi
     *buffer = '0';
     return (size_t)0;
   }
-  return unsignedstrconv_impl(value & ((UINTMAX_C(256) << ((--valsize) << 3)) - 1), buffer, bufsize, base);
+  return unsignedstrconv_impl(value & ((UINTMAX_C(256) << ((valsize-1) << 3)) - 1), buffer, bufsize, base);
 }
 
 size_t unsignedtowcs(uintmax_t value, size_t valsize, wchar_t *buffer, size_t bufsize, int base)
@@ -73,7 +73,7 @@ size_t unsignedtowcs(uintmax_t value, size_t valsize, wchar_t *buffer, size_t bu
     *buffer = L'0';
     return (size_t)0;
   }
-  return unsignedwcsconv_impl(value & ((UINTMAX_C(256) << ((--valsize) << 3)) - 1), buffer, bufsize, base);
+  return unsignedwcsconv_impl(value & ((UINTMAX_C(256) << ((valsize-1) << 3)) - 1), buffer, bufsize, base);
 }
 
 /* ########## private worker functions that perform the actual conversion ########## */


### PR DESCRIPTION
The static analyzer infer detected a dead store to valsize.
Indeed the value is changed but not read back.